### PR TITLE
Mensagens lançadas quando ocorrem erros

### DIFF
--- a/Database/apiConfiguracao.js
+++ b/Database/apiConfiguracao.js
@@ -10,7 +10,7 @@ class ApiConfiguracao {
 
       return await dboperations.getItem(_sql);
     } catch (error) {
-      utils.handleError(error, 'Não foi encontrada nenhuma configuração');
+      utils.handleError(error, error.message);
     }
   }
 }

--- a/Database/calendario.js
+++ b/Database/calendario.js
@@ -15,7 +15,7 @@ class Calendario {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foi encontrada a empresa com o código ' + filtro
+        error.message + ` para o empresa com o filtro ${filtro}`
       );
     }
   }
@@ -31,7 +31,7 @@ class Calendario {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foram encontradas folgas da empresa com o código ' + filtro
+        error.message + ` das folgas para o empresa com o filtro ${filtro}`
       );
     }
   }
@@ -77,10 +77,7 @@ class Calendario {
     } catch (error) {
       utils.handleError(
         error,
-        'Erro a obter as marcações com unidades de tempo do terapeuta com o código ' +
-          codigo +
-          ' e o filtro ' +
-          filtro
+        error.message + ` das marcações com unidades de tempo do terapeuta com o código ${codigo} e o filtro ${filtro}`
       );
     }
   }

--- a/Database/terapeuta.js
+++ b/Database/terapeuta.js
@@ -40,10 +40,8 @@ class Terapeuta {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foi encontrado o terapeuta com o código ' +
-          codigo +
-          ' e o filtro ' +
-          filtro
+        error.message + ` do terapeuta com o código ${codigo} e o filtro ${filtro}`
+
       );
     }
   }
@@ -83,7 +81,8 @@ class Terapeuta {
 
       return await dboperations.getList(_sql, params);
     } catch (error) {
-      utils.handleError(error, 'Não foram encontrados terapeutas');
+      utils.handleError(error, error.message
+      );
     }
   }
 
@@ -127,10 +126,8 @@ class Terapeuta {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foram encontradas aulas para o terapeuta com o código ' +
-          codigo +
-          ' e o filtro ' +
-          filtro
+        error.message + ` de aulas para o terapeuta com o código ${codigo} e o filtro ${filtro}`
+
       );
     }
   }
@@ -153,7 +150,7 @@ class Terapeuta {
     } catch (error) {
       utils.handleError(
         error,
-        'Erro a obter o horário variável do terapeuta com o código ' + codigo
+        error.message + `  horário variável do terapeuta com o código ${codigo} e o filtro ${filtro}`
       );
     }
   }
@@ -176,7 +173,8 @@ class Terapeuta {
     } catch (error) {
       utils.handleError(
         error,
-        'Erro a obter as folgas do terapeuta com o código ' + codigo
+        error.message + ` de folgas do terapeuta com o código ${codigo} e o filtro ${filtro}`
+
       );
     }
   }

--- a/Database/tratamento.js
+++ b/Database/tratamento.js
@@ -17,7 +17,7 @@ class Tratamento {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foi encontrado o tratamento com o código ' + codigo
+        error.message + ` do tratamento com o código ${codigo}`
       );
     }
   }
@@ -44,7 +44,7 @@ class Tratamento {
 
       return await dboperations.getList(_sql, params);
     } catch (error) {
-      utils.handleError(error, 'Não foram encontrados tratamentos');
+      utils.handleError(error, error.message);
     }
   }
 
@@ -83,7 +83,7 @@ class Tratamento {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foram encontradas aulas para o tratamento com o código ' + codigo
+        error.message + ` de aulas para o tratamento com o código ${codigo}`
       );
     }
   }

--- a/Database/utente.js
+++ b/Database/utente.js
@@ -23,7 +23,7 @@ class Utente {
     } catch (error) {
       utils.handleError(
         error,
-        'Não foi encontrado o utente com o código ' + codigo
+        error.message + ` do utente com o código ${codigo}`
       );
     }
   }
@@ -38,7 +38,7 @@ class Utente {
 
       return await dboperations.getList(_sql, params);
     } catch (error) {
-      utils.handleError(error, 'Não foram encontrados utentes');
+      utils.handleError(error, error.message);
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# api description
+# API INTEGRAÇÃO CLICLOUD-NKA
+
+Esta API permite fornecer serviços da aplicação CLILCOUD com a NKA.
+
+## Instalação
+
+Aceder à linha de comandos e executar o seguinte comando na diretoria do projeto para instalar os packages necessários.
+
+```bash
+npm install
+```
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)

--- a/Utils/dboperations.js
+++ b/Utils/dboperations.js
@@ -9,9 +9,9 @@ async function getList(_sql, _params) {
         _sql = replaceQueryParameters(_sql, index, param);
       });
     }
+    console.log(_sql)
     let pool = await sql.connect(config);
     let bd = await pool.request().query(_sql);
-
     return bd.recordset;
   } catch (error) {
     utils.handleError(error, 'Erro a obter a lista');
@@ -22,12 +22,14 @@ async function getItem(_sql, _params) {
   try {
     let result = await getList(_sql, _params);
 
+    if (result.length === 0)
+      throw new Error('Não foram encontrados registos');
     if (result.length > 1)
       throw new Error('Foram encontrados mais que um registo');
     if (result.length == 1) return result[0];
     // devolver undefined
   } catch (error) {
-    utils.handleError(error, 'Erro a obter item');
+    utils.handleError(error, error.message);
   }
 }
 

--- a/routes.js
+++ b/routes.js
@@ -22,6 +22,7 @@ router.get('/utente', verifyJWT, async (req, res, next) => {
       const utente = await Utente.getUtente(id);
       return res.json(utente);
     }
+    console.log('entrei')
     const utenteAll = await Utente.getAllUtentes();
     res.json(utenteAll);
   } catch (err) {


### PR DESCRIPTION
Devias testar esta versão e verificar se tudo está a correr como é suposto quando ocorrem erros. As alterações são para mostrar as diferentes mensagens de erro que estavam configuradas porque até então a mensagem era sobreposta pela do catch (não em todos os casos).